### PR TITLE
Grid size pixel fix

### DIFF
--- a/PretextSnapshot.cpp
+++ b/PretextSnapshot.cpp
@@ -2656,7 +2656,7 @@ FillInGrid_Thread(void *in)
                         AlphaBlendGrid_8Wide(pixelData);
                         u32 skipBackIndex = 0;
                         u32 backFillCount = 0;
-                        while (backFillCount < backCount && skipBackIndex <= range_y)
+                        while (backFillCount < backCount && skipBackIndex < range_y)
                         {
                             ++skipBackIndex;
                             u32 rowIdx = lastRow - skipBackIndex;
@@ -2675,7 +2675,7 @@ FillInGrid_Thread(void *in)
                         AlphaBlendGrid_4Wide(pixelData);
                         u32 skipBackIndex = 0;
                         u32 backFillCount = 0;
-                        while (backFillCount < backCount && skipBackIndex <= range_y)
+                        while (backFillCount < backCount && skipBackIndex < range_y)
                         {
                             ++skipBackIndex;
                             u32 rowIdx = lastRow - skipBackIndex;
@@ -2801,7 +2801,7 @@ FillInGrid_Thread(void *in)
                         AlphaBlendGrid_8Wide(pixelData);
                         u32 skipBackIndex = 0;
                         u32 backFillCount = 0;
-                        while (backFillCount < backCount && skipBackIndex <= range_x)
+                        while (backFillCount < backCount && skipBackIndex < range_x)
                         {
                             ++skipBackIndex;
                             u32 colIdx = index - skipBackIndex;
@@ -2820,7 +2820,7 @@ FillInGrid_Thread(void *in)
                         AlphaBlendGrid_4Wide(pixelData);
                         u32 skipBackIndex = 0;
                         u32 backFillCount = 0;
-                        while (backFillCount < backCount && skipBackIndex <= range_x)
+                        while (backFillCount < backCount && skipBackIndex < range_x)
                         {
                             ++skipBackIndex;
                             u32 colIdx = index - skipBackIndex;
@@ -2939,7 +2939,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 u32 backCount = countMod + 1;
                 AlphaBlendGrid_8Wide(pixelData);
                 u32 skipBackIndex = 0, backFillCount = 0;
-                while (backFillCount < backCount && skipBackIndex <= range_x)
+                while (backFillCount < backCount && skipBackIndex < range_x)
                 {
                     ++skipBackIndex;
                     u32 colIdx = index - skipBackIndex;
@@ -2957,7 +2957,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 u32 backCount = countMod + 1;
                 AlphaBlendGrid_4Wide(pixelData);
                 u32 skipBackIndex = 0, backFillCount = 0;
-                while (backFillCount < backCount && skipBackIndex <= range_x)
+                while (backFillCount < backCount && skipBackIndex < range_x)
                 {
                     ++skipBackIndex;
                     u32 colIdx = index - skipBackIndex;
@@ -3058,7 +3058,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 u32 backCount = countMod + 1;
                 AlphaBlendGrid_8Wide(pixelData);
                 u32 skipBackIndex = 0, backFillCount = 0;
-                while (backFillCount < backCount && skipBackIndex <= range_y)
+                while (backFillCount < backCount && skipBackIndex < range_y)
                 {
                     ++skipBackIndex;
                     u32 rowIdx = idx - skipBackIndex;
@@ -3076,7 +3076,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 u32 backCount = countMod + 1;
                 AlphaBlendGrid_4Wide(pixelData);
                 u32 skipBackIndex = 0, backFillCount = 0;
-                while (backFillCount < backCount && skipBackIndex <= range_y)
+                while (backFillCount < backCount && skipBackIndex < range_y)
                 {
                     ++skipBackIndex;
                     u32 rowIdx = idx - skipBackIndex;

--- a/PretextSnapshot.cpp
+++ b/PretextSnapshot.cpp
@@ -2601,6 +2601,7 @@ FillInGrid_Thread(void *in)
                             while (backFillCount < dataSize && skipBackIndex < range_y)
                             {
                                 ++skipBackIndex;
+                                if (skipBackIndex > row) continue;
                                 u32 rowIdx = row - skipBackIndex;
                                 if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                                 {
@@ -2619,6 +2620,7 @@ FillInGrid_Thread(void *in)
                             while (backFillCount < dataSize && skipBackIndex < range_y)
                             {
                                 ++skipBackIndex;
+                                if (skipBackIndex > row) continue;
                                 u32 rowIdx = row - skipBackIndex;
                                 if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                                 {
@@ -2659,6 +2661,7 @@ FillInGrid_Thread(void *in)
                         while (backFillCount < backCount && skipBackIndex <= range_y)
                         {
                             ++skipBackIndex;
+                            if (skipBackIndex > lastRow) continue;
                             u32 rowIdx = lastRow - skipBackIndex;
                             if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                             {
@@ -2678,6 +2681,7 @@ FillInGrid_Thread(void *in)
                         while (backFillCount < backCount && skipBackIndex <= range_y)
                         {
                             ++skipBackIndex;
+                            if (skipBackIndex > lastRow) continue;
                             u32 rowIdx = lastRow - skipBackIndex;
                             if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                             {
@@ -2746,6 +2750,7 @@ FillInGrid_Thread(void *in)
                                 while (backFillCount < dataSize && skipBackIndex < range_x)
                                 {
                                     ++skipBackIndex;
+                                    if (skipBackIndex > index) continue;
                                     u32 colIdx = index - skipBackIndex;
                                     if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                                     {
@@ -2764,6 +2769,7 @@ FillInGrid_Thread(void *in)
                                 while (backFillCount < dataSize && skipBackIndex < range_x)
                                 {
                                     ++skipBackIndex;
+                                    if (skipBackIndex > index) continue;
                                     u32 colIdx = index - skipBackIndex;
                                     if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                                     {
@@ -2804,6 +2810,7 @@ FillInGrid_Thread(void *in)
                         while (backFillCount < backCount && skipBackIndex <= range_x)
                         {
                             ++skipBackIndex;
+                            if (skipBackIndex > index) continue;
                             u32 colIdx = index - skipBackIndex;
                             if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                             {
@@ -2823,6 +2830,7 @@ FillInGrid_Thread(void *in)
                         while (backFillCount < backCount && skipBackIndex <= range_x)
                         {
                             ++skipBackIndex;
+                            if (skipBackIndex > index) continue;
                             u32 colIdx = index - skipBackIndex;
                             if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                             {
@@ -2888,6 +2896,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                         while (backFillCount < dataSize && skipBackIndex < range_x)
                         {
                             ++skipBackIndex;
+                            if (skipBackIndex > index) continue;
                             u32 colIdx = index - skipBackIndex;
                             if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                             {
@@ -2905,6 +2914,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                         while (backFillCount < dataSize && skipBackIndex < range_x)
                         {
                             ++skipBackIndex;
+                            if (skipBackIndex > index) continue;
                             u32 colIdx = index - skipBackIndex;
                             if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                             {
@@ -2942,6 +2952,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 while (backFillCount < backCount && skipBackIndex <= range_x)
                 {
                     ++skipBackIndex;
+                    if (skipBackIndex > index) continue;
                     u32 colIdx = index - skipBackIndex;
                     if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                     {
@@ -2960,6 +2971,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 while (backFillCount < backCount && skipBackIndex <= range_x)
                 {
                     ++skipBackIndex;
+                    if (skipBackIndex > index) continue;
                     u32 colIdx = index - skipBackIndex;
                     if (colIdx >= start_x && !CheckPixelBitFlag(colIdx, pixel, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                     {
@@ -3008,6 +3020,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                     while (backFillCount < dataSize && skipBackIndex < range_y)
                     {
                         ++skipBackIndex;
+                        if (skipBackIndex > idx) continue;
                         u32 rowIdx = idx - skipBackIndex;
                         if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                         {
@@ -3025,6 +3038,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                     while (backFillCount < dataSize && skipBackIndex < range_y)
                     {
                         ++skipBackIndex;
+                        if (skipBackIndex > idx) continue;
                         u32 rowIdx = idx - skipBackIndex;
                         if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                         {
@@ -3061,6 +3075,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 while (backFillCount < backCount && skipBackIndex <= range_y)
                 {
                     ++skipBackIndex;
+                    if (skipBackIndex > idx) continue;
                     u32 rowIdx = idx - skipBackIndex;
                     if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                     {
@@ -3079,6 +3094,7 @@ FillInGridCustomOrder(u32 resolution_x, u32 resolution_y)
                 while (backFillCount < backCount && skipBackIndex <= range_y)
                 {
                     ++skipBackIndex;
+                    if (skipBackIndex > idx) continue;
                     u32 rowIdx = idx - skipBackIndex;
                     if (rowIdx >= start_y && !CheckPixelBitFlag(pixel, rowIdx, resolution_x, Output_Buffer->outputImageBufferGridFillFlags))
                     {

--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ meson compile
 meson test
 meson install
 ```
+
+If `meson setup` fails with missing files under `libdeflate/` or `mpc/`, initialize submodules first:
+```bash
+git submodule update --init --recursive
+```
+Then rerun `meson setup ...`. If setup fails, `builddir` is not a valid Meson build directory yet, so `meson compile/test/install` will also fail until setup succeeds.

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,21 @@ project('PretextSnapshot', ['c', 'cpp'],
     version: '0.0.6'
 )
 
+fs = import('fs')
+required_submodule_files = [
+    'libdeflate/lib/x86/cpu_features.c',
+    'libdeflate/lib/deflate_compress.c',
+    'mpc/mpc.c',
+]
+
+foreach f : required_submodule_files
+    if not fs.exists(f)
+        error('Missing required source file: ' + f + '\n'
+              + 'PretextSnapshot depends on git submodules. Run:\n'
+              + '  git submodule update --init --recursive')
+    endif
+endforeach
+
 thread_dep = dependency('threads')
 math_dep = meson.get_compiler('cpp').find_library('m', required : true)
 cpp_dep = meson.get_compiler('cpp').find_library('stdc++', required : true)


### PR DESCRIPTION
Seg fault occurred when grid=1 due to index backflow, resulting under signed indices + calls to memory that don't exist.